### PR TITLE
Add Redis cache to speed up database queries

### DIFF
--- a/src/main/java/com/bezkoder/spring/jpa/h2/SpringBootJpaH2Application.java
+++ b/src/main/java/com/bezkoder/spring/jpa/h2/SpringBootJpaH2Application.java
@@ -2,8 +2,10 @@ package com.bezkoder.spring.jpa.h2;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class SpringBootJpaH2Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/bezkoder/spring/jpa/h2/controller/TutorialController.java
+++ b/src/main/java/com/bezkoder/spring/jpa/h2/controller/TutorialController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.bezkoder.spring.jpa.h2.model.Tutorial;
 import com.bezkoder.spring.jpa.h2.repository.TutorialRepository;
+import com.bezkoder.spring.jpa.h2.service.TutorialService;
 
 @CrossOrigin(origins = "http://localhost:8081")
 @RestController
@@ -28,6 +29,9 @@ public class TutorialController {
 
   @Autowired
   TutorialRepository tutorialRepository;
+
+  @Autowired
+  TutorialService tutorialService;
 
   @GetMapping("/tutorials")
   public ResponseEntity<List<Tutorial>> getAllTutorials(@RequestParam(required = false) String title) {
@@ -51,7 +55,7 @@ public class TutorialController {
 
   @GetMapping("/tutorials/{id}")
   public ResponseEntity<Tutorial> getTutorialById(@PathVariable("id") long id) {
-    Optional<Tutorial> tutorialData = tutorialRepository.findById(id);
+    Optional<Tutorial> tutorialData = tutorialService.getTutorialById(id);
 
     if (tutorialData.isPresent()) {
       return new ResponseEntity<>(tutorialData.get(), HttpStatus.OK);
@@ -88,7 +92,7 @@ public class TutorialController {
   @DeleteMapping("/tutorials/{id}")
   public ResponseEntity<HttpStatus> deleteTutorial(@PathVariable("id") long id) {
     try {
-      tutorialRepository.deleteById(id);
+      tutorialService.deleteTutorial(id);
       return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     } catch (Exception e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/bezkoder/spring/jpa/h2/repository/TutorialRepository.java
+++ b/src/main/java/com/bezkoder/spring/jpa/h2/repository/TutorialRepository.java
@@ -3,6 +3,8 @@ package com.bezkoder.spring.jpa.h2.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.CacheEvict;
 
 import com.bezkoder.spring.jpa.h2.model.Tutorial;
 
@@ -10,4 +12,13 @@ public interface TutorialRepository extends JpaRepository<Tutorial, Long> {
   List<Tutorial> findByPublished(boolean published);
 
   List<Tutorial> findByTitleContainingIgnoreCase(String title);
+
+  @Cacheable(value = "tutorials", key = "#id")
+  Optional<Tutorial> findById(Long id);
+
+  @CacheEvict(value = "tutorials", key = "#id")
+  void deleteById(Long id);
+
+  @CacheEvict(value = "tutorials", allEntries = true)
+  void deleteAll();
 }

--- a/src/main/java/com/bezkoder/spring/jpa/h2/service/TutorialService.java
+++ b/src/main/java/com/bezkoder/spring/jpa/h2/service/TutorialService.java
@@ -1,0 +1,28 @@
+package com.bezkoder.spring.jpa.h2.service;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Service;
+
+import com.bezkoder.spring.jpa.h2.model.Tutorial;
+import com.bezkoder.spring.jpa.h2.repository.TutorialRepository;
+
+@Service
+public class TutorialService {
+
+    @Autowired
+    private TutorialRepository tutorialRepository;
+
+    @Cacheable(value = "tutorials", key = "#id")
+    public Optional<Tutorial> getTutorialById(Long id) {
+        return tutorialRepository.findById(id);
+    }
+
+    @CacheEvict(value = "tutorials", key = "#id")
+    public void deleteTutorial(Long id) {
+        tutorialRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,10 @@ spring.datasource.password=
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto= update
+
+# Redis configuration
+spring.redis.host=localhost
+spring.redis.port=6379
+
+# Cache configuration
+spring.cache.type=redis

--- a/src/test/java/com/bezkoder/spring/jpa/h2/repository/TutorialRepositoryTests.java
+++ b/src/test/java/com/bezkoder/spring/jpa/h2/repository/TutorialRepositoryTests.java
@@ -1,0 +1,78 @@
+package com.bezkoder.spring.jpa.h2.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.bezkoder.spring.jpa.h2.SpringBootJpaH2Application;
+import com.bezkoder.spring.jpa.h2.model.Tutorial;
+
+@SpringBootTest
+@ContextConfiguration(classes = SpringBootJpaH2Application.class)
+@EnableCaching
+@DataJpaTest
+public class TutorialRepositoryTests {
+
+    @Autowired
+    private TutorialRepository tutorialRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    public void setUp() {
+        tutorialRepository.deleteAll();
+    }
+
+    @Test
+    public void testFindById_Cacheable() {
+        Tutorial tutorial = new Tutorial("Title", "Description", true);
+        tutorial = tutorialRepository.save(tutorial);
+
+        Optional<Tutorial> tutorialFromDb = tutorialRepository.findById(tutorial.getId());
+        assertThat(tutorialFromDb).isPresent();
+
+        Optional<Tutorial> tutorialFromCache = tutorialRepository.findById(tutorial.getId());
+        assertThat(tutorialFromCache).isPresent();
+
+        assertThat(cacheManager.getCache("tutorials").get(tutorial.getId())).isNotNull();
+    }
+
+    @Test
+    public void testDeleteById_CacheEvict() {
+        Tutorial tutorial = new Tutorial("Title", "Description", true);
+        tutorial = tutorialRepository.save(tutorial);
+
+        tutorialRepository.findById(tutorial.getId());
+        assertThat(cacheManager.getCache("tutorials").get(tutorial.getId())).isNotNull();
+
+        tutorialRepository.deleteById(tutorial.getId());
+        assertThat(cacheManager.getCache("tutorials").get(tutorial.getId())).isNull();
+    }
+
+    @Test
+    public void testDeleteAll_CacheEvict() {
+        Tutorial tutorial1 = new Tutorial("Title1", "Description1", true);
+        Tutorial tutorial2 = new Tutorial("Title2", "Description2", true);
+        tutorialRepository.save(tutorial1);
+        tutorialRepository.save(tutorial2);
+
+        tutorialRepository.findById(tutorial1.getId());
+        tutorialRepository.findById(tutorial2.getId());
+        assertThat(cacheManager.getCache("tutorials").get(tutorial1.getId())).isNotNull();
+        assertThat(cacheManager.getCache("tutorials").get(tutorial2.getId())).isNotNull();
+
+        tutorialRepository.deleteAll();
+        assertThat(cacheManager.getCache("tutorials").get(tutorial1.getId())).isNull();
+        assertThat(cacheManager.getCache("tutorials").get(tutorial2.getId())).isNull();
+    }
+}


### PR DESCRIPTION
Related to #4

Integrate Redis cache to speed up database queries in the Spring Boot application.

* **Add Redis Configuration:**
  - Update `src/main/resources/application.properties` to include Redis configuration properties.
  - Add cache configuration properties.

* **Enable Caching:**
  - Add `@EnableCaching` annotation to the `SpringBootJpaH2Application` class in `src/main/java/com/bezkoder/spring/jpa/h2/SpringBootJpaH2Application.java`.

* **Update Repository Methods:**
  - Add `@Cacheable` annotation to the `findById` method in `src/main/java/com/bezkoder/spring/jpa/h2/repository/TutorialRepository.java`.
  - Add `@CacheEvict` annotation to the `deleteById` and `deleteAll` methods in `src/main/java/com/bezkoder/spring/jpa/h2/repository/TutorialRepository.java`.

* **Create TutorialService:**
  - Add `@Cacheable` annotation to the `getTutorialById` method in `src/main/java/com/bezkoder/spring/jpa/h2/service/TutorialService.java`.
  - Add `@CacheEvict` annotation to the `deleteTutorial` method in `src/main/java/com/bezkoder/spring/jpa/h2/service/TutorialService.java`.

* **Update Controller:**
  - Update `getTutorialById` and `deleteTutorial` methods in `src/main/java/com/bezkoder/spring/jpa/h2/controller/TutorialController.java` to use `TutorialService` instead of `TutorialRepository`.

* **Add Unit Tests:**
  - Create a new test class `TutorialRepositoryTests` in `src/test/java/com/bezkoder/spring/jpa/h2/repository/TutorialRepositoryTests.java`.
  - Add unit tests to verify caching functionality.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snapxmin/spring-boot-h2-database-crud/pull/5?shareId=b8387215-cb1f-4b33-abbc-15d32148ec11).