### PR TITLE
Add Swagger UI for API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,8 @@ Run both Back-end & Front-end in one place:
 mvn spring-boot:run
 ```
 
+## Access Swagger UI
+After running the application, you can access the Swagger UI at:
+```
+http://localhost:8080/swagger-ui/
+```

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,25 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
+			<scope>test</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger2</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>3.0.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/bezkoder/spring/jpa/h2/config/SwaggerConfig.java
+++ b/src/main/java/com/bezkoder/spring/jpa/h2/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package com.bezkoder.spring.jpa.h2.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.bezkoder.spring.jpa.h2.controller"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/src/main/java/com/bezkoder/spring/jpa/h2/controller/TutorialController.java
+++ b/src/main/java/com/bezkoder/spring/jpa/h2/controller/TutorialController.java
@@ -21,14 +21,19 @@ import org.springframework.web.bind.annotation.RestController;
 import com.bezkoder.spring.jpa.h2.model.Tutorial;
 import com.bezkoder.spring.jpa.h2.repository.TutorialRepository;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
 @CrossOrigin(origins = "http://localhost:8081")
 @RestController
 @RequestMapping("/api")
+@Api(value = "Tutorial Management System")
 public class TutorialController {
 
   @Autowired
   TutorialRepository tutorialRepository;
 
+  @ApiOperation(value = "View a list of available tutorials", response = List.class)
   @GetMapping("/tutorials")
   public ResponseEntity<List<Tutorial>> getAllTutorials(@RequestParam(required = false) String title) {
     try {
@@ -49,6 +54,7 @@ public class TutorialController {
     }
   }
 
+  @ApiOperation(value = "Get a tutorial by Id")
   @GetMapping("/tutorials/{id}")
   public ResponseEntity<Tutorial> getTutorialById(@PathVariable("id") long id) {
     Optional<Tutorial> tutorialData = tutorialRepository.findById(id);
@@ -60,6 +66,7 @@ public class TutorialController {
     }
   }
 
+  @ApiOperation(value = "Create a new tutorial")
   @PostMapping("/tutorials")
   public ResponseEntity<Tutorial> createTutorial(@RequestBody Tutorial tutorial) {
     try {
@@ -70,6 +77,7 @@ public class TutorialController {
     }
   }
 
+  @ApiOperation(value = "Update an existing tutorial")
   @PutMapping("/tutorials/{id}")
   public ResponseEntity<Tutorial> updateTutorial(@PathVariable("id") long id, @RequestBody Tutorial tutorial) {
     Optional<Tutorial> tutorialData = tutorialRepository.findById(id);
@@ -85,6 +93,7 @@ public class TutorialController {
     }
   }
 
+  @ApiOperation(value = "Delete a tutorial by Id")
   @DeleteMapping("/tutorials/{id}")
   public ResponseEntity<HttpStatus> deleteTutorial(@PathVariable("id") long id) {
     try {
@@ -95,6 +104,7 @@ public class TutorialController {
     }
   }
 
+  @ApiOperation(value = "Delete all tutorials")
   @DeleteMapping("/tutorials")
   public ResponseEntity<HttpStatus> deleteAllTutorials() {
     try {
@@ -106,6 +116,7 @@ public class TutorialController {
 
   }
 
+  @ApiOperation(value = "Find tutorials by published status")
   @GetMapping("/tutorials/published")
   public ResponseEntity<List<Tutorial>> findByPublished() {
     try {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,5 @@ spring.datasource.password=
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto= update
+
+springfox.documentation.swagger.v2.path=/api-docs


### PR DESCRIPTION
Add Swagger UI support for API documentation and testing.

* **Dependencies**: Add `io.springfox:springfox-boot-starter:3.0.0`, `io.springfox:springfox-swagger2:3.0.0`, and `io.springfox:springfox-swagger-ui:3.0.0` to `pom.xml`.
* **Configuration**: Create `SwaggerConfig.java` to configure Swagger with `@Configuration` and `@EnableSwagger2` annotations.
* **Controller Annotations**: Annotate `TutorialController.java` with `@Api` and `@ApiOperation` for Swagger documentation.
* **Properties**: Add `springfox.documentation.swagger.v2.path=/api-docs` to `application.properties`.
* **Documentation**: Update `README.md` with instructions on how to access Swagger UI.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snapxmin/spring-boot-h2-database-crud/pull/7?shareId=e383eb7c-33ee-4c0c-8466-32ea5e6937af).